### PR TITLE
CHECKING initialization to TRUE

### DIFF
--- a/src/main/java/org/wildfly/security/manager/WildFlySecurityManager.java
+++ b/src/main/java/org/wildfly/security/manager/WildFlySecurityManager.java
@@ -78,7 +78,11 @@ public final class WildFlySecurityManager extends SecurityManager {
     private static final Permission GET_CLASS_LOADER_PERMISSION = new RuntimePermission("getClassLoader");
     private static final Permission SET_CLASS_LOADER_PERMISSION = new RuntimePermission("setClassLoader");
 
-    private static final InheritableThreadLocal<Boolean> CHECKING = new InheritableThreadLocal<>();
+    private static final InheritableThreadLocal<Boolean> CHECKING = new InheritableThreadLocal<Boolean>(){
+        protected Boolean initialValue(){
+            return TRUE;
+        }
+    };
     private static final ThreadLocal<Boolean> ENTERED = new ThreadLocal<Boolean>();
 
     private static final Field PD_STACK;


### PR DESCRIPTION
Deployment's code was not checked, so I prepared this patch.
I use it in my bachelor thesis, [jsm-policy-subsystem](https://github.com/honza889/jsm-policy-subsystem), because java security policy files support.
